### PR TITLE
feat: add comprehensive webhook logging support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,12 @@
 {
     "name": "basementdevs/filament-better-mails",
-    "version": "5.1.0",
+    "version": "5.1.1",
     "description": "This is my package filament-better-mails",
     "keywords": [
         "Basement Developers",
         "laravel",
         "filament-better-mails"
     ],
-    "version": "5.0.1",
     "homepage": "https://github.com/basementdevs/filament-better-mails",
     "license": "MIT",
     "authors": [
@@ -20,16 +19,17 @@
     "require": {
         "php": "^8.3",
         "filament/filament": "^5.0",
-        "illuminate/contracts": "^12.0",
-        "resend/resend-laravel": "^0.22.0",
+        "illuminate/contracts": "^12.0||^13.0",
+        "resend/resend-laravel": "^1.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
         "driftingly/rector-laravel": "^2.0.4",
         "larastan/larastan": "^3.0",
+        "laravel/boost": "^2.3",
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.8",
-        "orchestra/testbench": "^10.0.0||^9.0.0",
+        "orchestra/testbench": "^11.0.0||^10.0.0||^9.0.0",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-arch": "^4.0",
         "pestphp/pest-plugin-laravel": "^4.0",

--- a/config/filament-better-mails.php
+++ b/config/filament-better-mails.php
@@ -39,11 +39,10 @@ return [
         ]
     ],
     'webhooks' => [
-        'log_unknown_events' => env('MAILS_LOG_UNKNOWN_EVENTS', true),
         'provider' => env('MAILS_WEBHOOK_PROVIDER', 'resend'),
         'logging' => [
             'channel' => env('MAILS_WEBHOOK_LOG_CHANNEL'),
-            'enabled' => env('MAILS_WEBHOOK_LOGGING_ENABLED', true),
+            'enabled' => env('MAILS_WEBHOOK_LOGGING_ENABLED', false),
         ],
 
         'drivers' => [

--- a/config/filament-better-mails.php
+++ b/config/filament-better-mails.php
@@ -41,6 +41,10 @@ return [
     'webhooks' => [
         'log_unknown_events' => env('MAILS_LOG_UNKNOWN_EVENTS', true),
         'provider' => env('MAILS_WEBHOOK_PROVIDER', 'resend'),
+        'logging' => [
+            'channel' => env('MAILS_WEBHOOK_LOG_CHANNEL'),
+            'enabled' => env('MAILS_WEBHOOK_LOGGING_ENABLED', true),
+        ],
 
         'drivers' => [
             'resend' => [

--- a/src/Core/Http/Controllers/WebhookController.php
+++ b/src/Core/Http/Controllers/WebhookController.php
@@ -4,9 +4,11 @@ namespace Basement\BetterMails\Core\Http\Controllers;
 
 use Basement\BetterMails\Core\Contracts\BetterDriverContract;
 use Basement\BetterMails\Core\Enums\SupportedMailProvidersEnum;
+use Basement\BetterMails\Core\Support\BetterMailLogger;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Pipeline;
+use Symfony\Component\HttpFoundation\Response;
 
 final class WebhookController extends Controller
 {
@@ -14,10 +16,28 @@ final class WebhookController extends Controller
     {
         $provider = SupportedMailProvidersEnum::tryFrom($provider);
 
-        Pipeline::send($request)
+        BetterMailLogger::info('Webhook received.', [
+            'provider' => $provider?->value,
+            'type' => $request->input('type'),
+            'request_headers' => $request->headers->all(),
+            'payload' => $request->all(),
+        ]);
+
+        $result = Pipeline::send($request)
             ->through($provider->getMiddleware())
             ->thenReturn();
 
+        if ($result instanceof Response) {
+            return $result;
+        }
+
         $driver->handle($request->all());
+
+        BetterMailLogger::info('Webhook processed successfully.', [
+            'provider' => $provider?->value,
+            'type' => $request->input('type'),
+        ]);
+
+        return response()->json(['message' => 'Webhook processed.'], 200);
     }
 }

--- a/src/Core/Support/BetterMailLogger.php
+++ b/src/Core/Support/BetterMailLogger.php
@@ -14,7 +14,7 @@ final class BetterMailLogger
             return;
         }
 
-        static::log('debug', $message, $context);
+        self::log('debug', $message, $context);
     }
 
     public static function info(string $message, array $context = []): void
@@ -23,17 +23,17 @@ final class BetterMailLogger
             return;
         }
 
-        static::log('info', $message, $context);
+        self::log('info', $message, $context);
     }
 
     public static function warning(string $message, array $context = []): void
     {
-        static::log('warning', $message, $context);
+        self::log('warning', $message, $context);
     }
 
     public static function error(string $message, array $context = []): void
     {
-        static::log('error', $message, $context);
+        self::log('error', $message, $context);
     }
 
     private static function log(string $level, string $message, array $context): void

--- a/src/Core/Support/BetterMailLogger.php
+++ b/src/Core/Support/BetterMailLogger.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Basement\BetterMails\Core\Support;
+
+use Illuminate\Support\Facades\Log;
+
+final class BetterMailLogger
+{
+    private const PREFIX = 'BetterMails';
+
+    public static function debug(string $message, array $context = []): void
+    {
+        if (! config('filament-better-mails.webhooks.logging.enabled', true)) {
+            return;
+        }
+
+        static::log('debug', $message, $context);
+    }
+
+    public static function info(string $message, array $context = []): void
+    {
+        if (! config('filament-better-mails.webhooks.logging.enabled', true)) {
+            return;
+        }
+
+        static::log('info', $message, $context);
+    }
+
+    public static function warning(string $message, array $context = []): void
+    {
+        static::log('warning', $message, $context);
+    }
+
+    public static function error(string $message, array $context = []): void
+    {
+        static::log('error', $message, $context);
+    }
+
+    private static function log(string $level, string $message, array $context): void
+    {
+        $channel = config('filament-better-mails.webhooks.logging.channel');
+        $prefixed = self::PREFIX.': '.$message;
+
+        if ($channel) {
+            Log::channel($channel)->{$level}($prefixed, $context);
+        } else {
+            Log::{$level}($prefixed, $context);
+        }
+    }
+}

--- a/src/Resend/Email/DTOs/ResendWebhookReceivedMailDTO.php
+++ b/src/Resend/Email/DTOs/ResendWebhookReceivedMailDTO.php
@@ -27,7 +27,7 @@ final readonly class ResendWebhookReceivedMailDTO implements BetterMailDTOContra
 
         $mailUuid = $dto['data']['headers'][0]['value'];
 
-        return new static(
+        return new self(
             id: Uuid::fromString($mailUuid),
             event: $event,
             payload: $dto,

--- a/src/Resend/Email/DTOs/ResendWebhookReceivedMailDTO.php
+++ b/src/Resend/Email/DTOs/ResendWebhookReceivedMailDTO.php
@@ -17,7 +17,7 @@ final readonly class ResendWebhookReceivedMailDTO implements BetterMailDTOContra
         public ?array $payload,
     ) {}
 
-    public static function fromWebhook(array $dto): ?self
+    public static function fromWebhook(array $dto): ?static
     {
         $event = ResendEventsEnum::tryFrom($dto['type'] ?? '');
 
@@ -27,7 +27,7 @@ final readonly class ResendWebhookReceivedMailDTO implements BetterMailDTOContra
 
         $mailUuid = $dto['data']['headers'][0]['value'];
 
-        return new self(
+        return new static(
             id: Uuid::fromString($mailUuid),
             event: $event,
             payload: $dto,

--- a/src/Resend/Email/Middleware/VerifyHeaderWebhookSignature.php
+++ b/src/Resend/Email/Middleware/VerifyHeaderWebhookSignature.php
@@ -5,6 +5,7 @@ namespace Basement\BetterMails\Resend\Email\Middleware;
 use Basement\BetterMails\Core\Contracts\BetterMiddlewareContract;
 use Basement\BetterMails\Core\Exceptions\MailException;
 use Basement\BetterMails\Core\Http\Middleware\AbstractMailMiddleware;
+use Basement\BetterMails\Core\Support\BetterMailLogger;
 use Closure;
 use Illuminate\Http\Request;
 
@@ -17,7 +18,24 @@ class VerifyHeaderWebhookSignature extends AbstractMailMiddleware implements Bet
     {
         $headers = $request->input('data.headers');
 
+        if (! is_array($headers)) {
+            BetterMailLogger::warning('Webhook received without email headers, skipping.', [
+                'type' => $request->input('type'),
+                'email_id' => $request->input('data.email_id'),
+                'request_headers' => $request->headers->all(),
+                'payload' => $request->all(),
+            ]);
+
+            return response()->json(['message' => 'Webhook received, but no trackable headers found.'], 200);
+        }
+
         parent::validateHeaderKey($headers, 'name', 'value');
+
+        BetterMailLogger::info('Email header validation passed.', [
+            'type' => $request->input('type'),
+            'request_headers' => $request->headers->all(),
+            'payload' => $request->all(),
+        ]);
 
         return $next($request);
     }

--- a/src/Resend/Email/Middleware/VerifyWebhookSignatureAdapter.php
+++ b/src/Resend/Email/Middleware/VerifyWebhookSignatureAdapter.php
@@ -4,6 +4,7 @@ namespace Basement\BetterMails\Resend\Email\Middleware;
 
 use Basement\BetterMails\Core\Contracts\BetterMiddlewareContract;
 use Basement\BetterMails\Core\Http\Middleware\AbstractMailMiddleware;
+use Basement\BetterMails\Core\Support\BetterMailLogger;
 use Closure;
 use Illuminate\Http\Request;
 use Resend\Laravel\Http\Middleware\VerifyWebhookSignature;
@@ -12,8 +13,13 @@ final class VerifyWebhookSignatureAdapter extends AbstractMailMiddleware impleme
 {
     public function handle(Request $request, Closure $next): mixed
     {
-        $middleware = new VerifyWebhookSignature;
+        BetterMailLogger::info('Verifying webhook signature.', ['provider' => 'resend']);
 
-        return $middleware->handle($request, $next);
+        $middleware = new VerifyWebhookSignature;
+        $result = $middleware->handle($request, $next);
+
+        BetterMailLogger::info('Webhook signature verified.', ['provider' => 'resend']);
+
+        return $result;
     }
 }

--- a/src/Resend/ResendDriver.php
+++ b/src/Resend/ResendDriver.php
@@ -17,7 +17,7 @@ use Basement\BetterMails\Resend\Email\Events\ResendEmailScheduledEvent;
 use Basement\BetterMails\Resend\Email\Events\ResendEmailSentEvent;
 use Basement\BetterMails\Resend\Email\Events\ResendEmailSuppressedEvent;
 use Basement\BetterMails\Resend\Email\ResendEventsEnum;
-use Illuminate\Support\Facades\Log;
+use Basement\BetterMails\Core\Support\BetterMailLogger;
 
 final class ResendDriver extends AbstractMailDriver implements BetterDriverContract
 {
@@ -30,7 +30,7 @@ final class ResendDriver extends AbstractMailDriver implements BetterDriverContr
 
         if ($dto === null) {
             if (config('filament-better-mails.webhooks.log_unknown_events', true)) {
-                Log::warning('BetterMails: Received unknown Resend webhook event type, skipping.', [
+                BetterMailLogger::warning('Received unknown Resend webhook event type, skipping.', [
                     'type' => $data['type'] ?? null,
                 ]);
             }
@@ -51,5 +51,10 @@ final class ResendDriver extends AbstractMailDriver implements BetterDriverContr
             ResendEventsEnum::EmailScheduled => ResendEmailScheduledEvent::dispatch($dto),
             ResendEventsEnum::EmailSuppressed => ResendEmailSuppressedEvent::dispatch($dto),
         };
+
+        BetterMailLogger::info('Event dispatched.', [
+            'event' => $dto->event->value,
+            'mail_uuid' => $dto->id,
+        ]);
     }
 }

--- a/src/Resend/ResendDriver.php
+++ b/src/Resend/ResendDriver.php
@@ -29,11 +29,9 @@ final class ResendDriver extends AbstractMailDriver implements BetterDriverContr
         $dto = ResendWebhookReceivedMailDTO::fromWebhook($data);
 
         if ($dto === null) {
-            if (config('filament-better-mails.webhooks.log_unknown_events', true)) {
-                BetterMailLogger::warning('Received unknown Resend webhook event type, skipping.', [
-                    'type' => $data['type'] ?? null,
-                ]);
-            }
+            BetterMailLogger::warning('Received unknown Resend webhook event type, skipping.', [
+                'type' => $data['type'] ?? null,
+            ]);
 
             return;
         }

--- a/src/Resend/ResendDriver.php
+++ b/src/Resend/ResendDriver.php
@@ -4,6 +4,7 @@ namespace Basement\BetterMails\Resend;
 
 use Basement\BetterMails\Core\AbstractMailDriver;
 use Basement\BetterMails\Core\Contracts\BetterDriverContract;
+use Basement\BetterMails\Core\Support\BetterMailLogger;
 use Basement\BetterMails\Resend\Email\DTOs\ResendWebhookReceivedMailDTO;
 use Basement\BetterMails\Resend\Email\Events\ResendEmailClickedEvent;
 use Basement\BetterMails\Resend\Email\Events\ResendEmailComplainedEvent;
@@ -17,7 +18,6 @@ use Basement\BetterMails\Resend\Email\Events\ResendEmailScheduledEvent;
 use Basement\BetterMails\Resend\Email\Events\ResendEmailSentEvent;
 use Basement\BetterMails\Resend\Email\Events\ResendEmailSuppressedEvent;
 use Basement\BetterMails\Resend\Email\ResendEventsEnum;
-use Basement\BetterMails\Core\Support\BetterMailLogger;
 
 final class ResendDriver extends AbstractMailDriver implements BetterDriverContract
 {

--- a/tests/Feature/Core/Support/BetterMailLoggerTest.php
+++ b/tests/Feature/Core/Support/BetterMailLoggerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use Basement\BetterMails\Core\Support\BetterMailLogger;
+use Illuminate\Support\Facades\Log;
+
+it('should use default channel when no channel is configured', function () {
+    config()->set('filament-better-mails.webhooks.logging.channel', null);
+    config()->set('filament-better-mails.webhooks.logging.enabled', true);
+
+    Log::shouldReceive('warning')
+        ->once()
+        ->with('BetterMails: Test warning.', ['key' => 'value']);
+
+    BetterMailLogger::warning('Test warning.', ['key' => 'value']);
+});
+
+it('should use specified channel when configured', function () {
+    config()->set('filament-better-mails.webhooks.logging.channel', 'resend');
+    config()->set('filament-better-mails.webhooks.logging.enabled', true);
+
+    $logger = Mockery::mock(\Psr\Log\LoggerInterface::class);
+    $logger->shouldReceive('warning')
+        ->once()
+        ->with('BetterMails: Test warning.', ['key' => 'value']);
+
+    Log::shouldReceive('channel')
+        ->with('resend')
+        ->once()
+        ->andReturn($logger);
+
+    BetterMailLogger::warning('Test warning.', ['key' => 'value']);
+});
+
+it('should suppress info logs when logging is disabled', function () {
+    config()->set('filament-better-mails.webhooks.logging.channel', null);
+    config()->set('filament-better-mails.webhooks.logging.enabled', false);
+
+    Log::shouldReceive('info')->never();
+
+    BetterMailLogger::info('This should not be logged.');
+});
+
+it('should not suppress warning logs when logging is disabled', function () {
+    config()->set('filament-better-mails.webhooks.logging.channel', null);
+    config()->set('filament-better-mails.webhooks.logging.enabled', false);
+
+    Log::shouldReceive('warning')
+        ->once()
+        ->with('BetterMails: This should be logged.', []);
+
+    BetterMailLogger::warning('This should be logged.');
+});
+
+it('should suppress debug logs when logging is disabled', function () {
+    config()->set('filament-better-mails.webhooks.logging.channel', null);
+    config()->set('filament-better-mails.webhooks.logging.enabled', false);
+
+    Log::shouldReceive('debug')->never();
+
+    BetterMailLogger::debug('This should not be logged.');
+});
+
+it('should not suppress error logs when logging is disabled', function () {
+    config()->set('filament-better-mails.webhooks.logging.channel', null);
+    config()->set('filament-better-mails.webhooks.logging.enabled', false);
+
+    Log::shouldReceive('error')
+        ->once()
+        ->with('BetterMails: This should be logged.', []);
+
+    BetterMailLogger::error('This should be logged.');
+});

--- a/tests/Feature/Core/Support/BetterMailLoggerTest.php
+++ b/tests/Feature/Core/Support/BetterMailLoggerTest.php
@@ -2,6 +2,7 @@
 
 use Basement\BetterMails\Core\Support\BetterMailLogger;
 use Illuminate\Support\Facades\Log;
+use Psr\Log\LoggerInterface;
 
 it('should use default channel when no channel is configured', function () {
     config()->set('filament-better-mails.webhooks.logging.channel', null);
@@ -18,7 +19,7 @@ it('should use specified channel when configured', function () {
     config()->set('filament-better-mails.webhooks.logging.channel', 'resend');
     config()->set('filament-better-mails.webhooks.logging.enabled', true);
 
-    $logger = Mockery::mock(\Psr\Log\LoggerInterface::class);
+    $logger = Mockery::mock(LoggerInterface::class);
     $logger->shouldReceive('warning')
         ->once()
         ->with('BetterMails: Test warning.', ['key' => 'value']);

--- a/tests/Feature/Resend/Driver/ResendDriverTest.php
+++ b/tests/Feature/Resend/Driver/ResendDriverTest.php
@@ -162,6 +162,7 @@ it('should be able to update email status to bounced', function () {
 });
 
 it('should return 200 and log warning for unknown event type', function () {
+    Log::shouldReceive('info')->zeroOrMoreTimes();
     Log::shouldReceive('warning')
         ->once()
         ->with('BetterMails: Received unknown Resend webhook event type, skipping.', [
@@ -194,6 +195,7 @@ it('should return 200 and log warning for unknown event type', function () {
 });
 
 it('should return 200 and log warning when type key is missing', function () {
+    Log::shouldReceive('info')->zeroOrMoreTimes();
     Log::shouldReceive('warning')
         ->once()
         ->with('BetterMails: Received unknown Resend webhook event type, skipping.', [

--- a/tests/Feature/Resend/MIddleware/VerifyResendWebhookSignatureTest.php
+++ b/tests/Feature/Resend/MIddleware/VerifyResendWebhookSignatureTest.php
@@ -3,6 +3,7 @@
 use Basement\BetterMails\Core\Enums\SupportedMailProvidersEnum;
 use Basement\BetterMails\Core\Exceptions\MailException;
 use Basement\BetterMails\Resend\Email\Middleware\VerifyWebhookSignatureAdapter;
+use Illuminate\Support\Facades\Log;
 
 use function Pest\Laravel\postJson;
 use function Pest\Laravel\withoutExceptionHandling;
@@ -34,3 +35,42 @@ it('should throw exception if mail header was not sent', function (): void {
     'Uuid mail signature not found on body request',
     403
 );
+
+it('should return 200 and log warning when data.headers is null', function (): void {
+    $this->withoutMiddleware(VerifyWebhookSignatureAdapter::class);
+
+    Log::shouldReceive('warning')->once();
+    Log::shouldReceive('info')->zeroOrMoreTimes();
+
+    $response = postJson(
+        route('filament-better-mails.webhook.store', ['provider' => SupportedMailProvidersEnum::Resend]),
+        [
+            'data' => [
+                'created_at' => '2025-10-05 23:59:51.98696+00',
+                'email_id' => 'b5482019-eef5-4afd-89ae-b93acb1dda7f',
+                'from' => '"Laravel" <onboarding@resend.dev>',
+                'subject' => 'Test Mail',
+                'to' => ['delivered@resend.dev'],
+            ],
+            'type' => 'email.delivered',
+        ]
+    );
+
+    $response->assertOk();
+});
+
+it('should return 200 and log warning when data is missing entirely', function (): void {
+    $this->withoutMiddleware(VerifyWebhookSignatureAdapter::class);
+
+    Log::shouldReceive('warning')->once();
+    Log::shouldReceive('info')->zeroOrMoreTimes();
+
+    $response = postJson(
+        route('filament-better-mails.webhook.store', ['provider' => SupportedMailProvidersEnum::Resend]),
+        [
+            'type' => 'email.delivered',
+        ]
+    );
+
+    $response->assertOk();
+});


### PR DESCRIPTION
## Summary
- Add `BetterMailLogger` utility class with configurable channel and enable/disable toggle
- Add logging at key webhook processing points (received, validated, processed)
- Handle missing `data.headers` gracefully with a 200 response and warning log
- Update dependencies and bump version to 5.1.1
- Add tests for `BetterMailLogger` and missing headers edge cases

### Files changed
- `composer.json` - deps update, version bump
- `config/filament-better-mails.php` - logging config options
- `src/Core/Http/Controllers/WebhookController.php` - add logging
- `src/Core/Support/BetterMailLogger.php` - new logger class
- `src/Resend/Email/Middleware/VerifyHeaderWebhookSignature.php` - graceful handling + logging
- `src/Resend/Email/Middleware/VerifyWebhookSignatureAdapter.php` - add logging
- `src/Resend/ResendDriver.php` - use BetterMailLogger instead of Log
- `tests/Feature/Core/Support/BetterMailLoggerTest.php` - new tests
- `tests/Feature/Resend/Driver/ResendDriverTest.php` - updated mocks
- `tests/Feature/Resend/Middleware/VerifyResendWebhookSignatureTest.php` - new tests