### PR TITLE
feat: cross domain

### DIFF
--- a/config/filament-better-mails.php
+++ b/config/filament-better-mails.php
@@ -40,6 +40,20 @@ return [
     ],
     'webhooks' => [
         'provider' => env('MAILS_WEBHOOK_PROVIDER', 'resend'),
+
+        /*
+        | Only process webhook events whose sender matches one of these values.
+        | Useful when several apps share the same provider account and every
+        | endpoint receives events for all sending. Each value may be a full
+        | email address ("noreply@flammabeneficios.com") or a bare domain
+        | ("flammabeneficios.com"). Leave empty to process everything.
+        | Comma separated.
+        */
+        'allowed_senders' => array_values(array_filter(array_map(
+            'trim',
+            explode(',', (string) env('MAILS_WEBHOOK_ALLOWED_SENDERS', ''))
+        ))),
+
         'logging' => [
             'channel' => env('MAILS_WEBHOOK_LOG_CHANNEL'),
             'enabled' => env('MAILS_WEBHOOK_LOGGING_ENABLED', false),

--- a/src/Core/Enums/SupportedMailProvidersEnum.php
+++ b/src/Core/Enums/SupportedMailProvidersEnum.php
@@ -3,6 +3,7 @@
 namespace Basement\BetterMails\Core\Enums;
 
 use Basement\BetterMails\Core\Contracts\BetterMiddlewareContract;
+use Basement\BetterMails\Resend\Email\Middleware\FilterAllowedSenders;
 use Basement\BetterMails\Resend\Email\Middleware\VerifyHeaderWebhookSignature;
 use Basement\BetterMails\Resend\Email\Middleware\VerifyWebhookSignatureAdapter;
 
@@ -16,7 +17,7 @@ enum SupportedMailProvidersEnum: string
     public function getMiddleware(): array
     {
         return match ($this) {
-            self::Resend => [VerifyWebhookSignatureAdapter::class, VerifyHeaderWebhookSignature::class],
+            self::Resend => [VerifyWebhookSignatureAdapter::class, FilterAllowedSenders::class, VerifyHeaderWebhookSignature::class],
         };
     }
 }

--- a/src/Filament/Widgets/BetterEmailStatsWidget.php
+++ b/src/Filament/Widgets/BetterEmailStatsWidget.php
@@ -50,25 +50,25 @@ class BetterEmailStatsWidget extends BaseWidget
 
         $widgets[] = Stat::make(__('Delivered'), number_format(($deliveredMails / $mailCount) * 100, 1).'%')
             ->label(__('Delivered'))
-            ->description($deliveredMails.' '.(string) __('of').' '.$mailCount.' '.(string) __('emails'))
+            ->description(__(':count of :total emails', ['count' => $deliveredMails, 'total' => $mailCount]))
             ->color('success')
             ->url($generateUrl('delivered'));
 
         $widgets[] = Stat::make(__('Opened'), number_format(($openedMails / $mailCount) * 100, 1).'%')
             ->label(__('Opened'))
-            ->description($openedMails.' '.(string) __('of').' '.$mailCount.' '.(string) __('emails'))
+            ->description(__(':count of :total emails', ['count' => $openedMails, 'total' => $mailCount]))
             ->color('info')
             ->url($generateUrl('opened'));
 
         $widgets[] = Stat::make(__('Clicked'), number_format(($clickedMails / $mailCount) * 100, 1).'%')
             ->label(__('Clicked'))
-            ->description($clickedMails.' '.(string) __('of').' '.$mailCount.' '.(string) __('emails'))
+            ->description(__(':count of :total emails', ['count' => $clickedMails, 'total' => $mailCount]))
             ->color('clicked')
             ->url($generateUrl('clicked'));
 
         $widgets[] = Stat::make(__('Bounced'), number_format(($bouncedMails / $mailCount) * 100, 1).'%')
             ->label(__('Bounced'))
-            ->description($bouncedMails.' '.(string) __('of').' '.$mailCount.' '.(string) __('emails'))
+            ->description(__(':count of :total emails', ['count' => $bouncedMails, 'total' => $mailCount]))
             ->color('danger')
             ->url($generateUrl('bounced'));
 

--- a/src/Resend/Email/Middleware/FilterAllowedSenders.php
+++ b/src/Resend/Email/Middleware/FilterAllowedSenders.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Basement\BetterMails\Resend\Email\Middleware;
+
+use Basement\BetterMails\Core\Contracts\BetterMiddlewareContract;
+use Basement\BetterMails\Core\Support\BetterMailLogger;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+final class FilterAllowedSenders implements BetterMiddlewareContract
+{
+    public function handle(Request $request, Closure $next): mixed
+    {
+        $allowed = config('filament-better-mails.webhooks.allowed_senders', []);
+
+        if (empty($allowed)) {
+            return $next($request);
+        }
+
+        $email = $this->extractEmail((string) $request->input('data.from', ''));
+        $domain = Str::after($email, '@');
+
+        $matches = collect($allowed)->contains(function ($value) use ($email, $domain): bool {
+            $value = strtolower(trim((string) $value));
+
+            return str_contains($value, '@')
+                ? $value === $email
+                : $value !== '' && $value === $domain;
+        });
+
+        if (! $matches) {
+            BetterMailLogger::info('Webhook ignored: sender not in allowed list.', [
+                'type' => $request->input('type'),
+                'from' => $request->input('data.from'),
+            ]);
+
+            return response()->json(['message' => 'Webhook ignored: sender not allowed.'], 200);
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Extract the bare email address from a "Name <email@domain>" style string.
+     */
+    private function extractEmail(string $from): string
+    {
+        if (preg_match('/<([^>]+)>/', $from, $matches)) {
+            $from = $matches[1];
+        }
+
+        return strtolower(trim($from));
+    }
+}

--- a/tests/Feature/Resend/MIddleware/FilterAllowedSendersTest.php
+++ b/tests/Feature/Resend/MIddleware/FilterAllowedSendersTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use Basement\BetterMails\Core\Enums\SupportedMailProvidersEnum;
+use Basement\BetterMails\Resend\Email\Middleware\VerifyWebhookSignatureAdapter;
+
+use function Pest\Laravel\postJson;
+
+/**
+ * Posts a Resend webhook with the given sender and no trackable headers.
+ * Without headers the request short-circuits at VerifyHeaderWebhookSignature
+ * with a distinctive 200 message, so we can tell "passed the sender filter"
+ * apart from "filtered out by the sender filter".
+ */
+function postResendWebhook(string $from)
+{
+    return postJson(
+        route('filament-better-mails.webhook.store', ['provider' => SupportedMailProvidersEnum::Resend]),
+        [
+            'data' => [
+                'created_at' => '2025-10-05 23:59:51.98696+00',
+                'email_id' => 'b5482019-eef5-4afd-89ae-b93acb1dda7f',
+                'from' => $from,
+                'subject' => 'Test Mail',
+                'to' => ['delivered@resend.dev'],
+            ],
+            'type' => 'email.delivered',
+        ]
+    );
+}
+
+beforeEach(function (): void {
+    $this->withoutMiddleware(VerifyWebhookSignatureAdapter::class);
+});
+
+it('processes every sender when the allow list is empty', function (): void {
+    config()->set('filament-better-mails.webhooks.allowed_senders', []);
+
+    postResendWebhook('"Flamma" <noreply@flammabeneficios.com>')
+        ->assertOk()
+        ->assertJson(['message' => 'Webhook received, but no trackable headers found.']);
+});
+
+it('lets the request through when the sender domain matches', function (): void {
+    config()->set('filament-better-mails.webhooks.allowed_senders', ['flammabeneficios.com']);
+
+    postResendWebhook('"Flamma" <noreply@flammabeneficios.com>')
+        ->assertOk()
+        ->assertJson(['message' => 'Webhook received, but no trackable headers found.']);
+});
+
+it('lets the request through when the full sender email matches', function (): void {
+    config()->set('filament-better-mails.webhooks.allowed_senders', ['noreply@flammabeneficios.com']);
+
+    postResendWebhook('"Flamma" <noreply@flammabeneficios.com>')
+        ->assertOk()
+        ->assertJson(['message' => 'Webhook received, but no trackable headers found.']);
+});
+
+it('ignores the event when the sender is not in the allow list', function (): void {
+    config()->set('filament-better-mails.webhooks.allowed_senders', ['flammabeneficios.com']);
+
+    postResendWebhook('"Flare" <noreply@flaredigital.com>')
+        ->assertOk()
+        ->assertJson(['message' => 'Webhook ignored: sender not allowed.']);
+});
+
+it('matches the sender case-insensitively', function (): void {
+    config()->set('filament-better-mails.webhooks.allowed_senders', ['Flammabeneficios.COM']);
+
+    postResendWebhook('"Flamma" <NoReply@FlammaBeneficios.com>')
+        ->assertOk()
+        ->assertJson(['message' => 'Webhook received, but no trackable headers found.']);
+});


### PR DESCRIPTION
Fixing widget label error.
Making sure that only allowed domain will pass at webhook (disabled by default)